### PR TITLE
feat: add support for new credential types

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ Install dependencies
 pnpm i
 ```
 
-Run development server
+Setup local env and run development server
+
+```shell
+cp .env.example .env.local
+```
 
 ```shell
 pnpm dev

--- a/components/DeveloperInfo.tsx
+++ b/components/DeveloperInfo.tsx
@@ -4,7 +4,8 @@ import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, Dia
 import {Input} from "./ui/input";
 import {Label} from "./ui/label";
 import {
-  ATP_LIST_HASH,
+  ATP_EQUIVALENT_LIST_HASH,
+  ATP_LIST_HASH, AUTHORITY_LIST_HASH,
   IDENTITY_LIST_HASH, PBL_INT_REGISTRY_ADDRESS, PRD_REGISTRY_ADDRESS, PRD_SAFE_ADDRESS,
   STK_INT_REGISTRY_ADDRESS,
   STK_INT_SAFE_ADDRESS,
@@ -13,7 +14,7 @@ import {
 import {useAccount} from "wagmi";
 
 type ButtonTextsState = Record<string, string>;
-const copyButtonKeys: string[] = ['atpListHash', 'idListHash', 'prdContract', 'prdNamespace', 'stkIntContract', 'stkIntNamespace', 'wltIntContract', 'wltIntNamespace', 'pblIntContract', 'pblIntNamespace'];
+const copyButtonKeys: string[] = ['atpListHash', 'equivalentHash', 'authorityHash', 'idListHash', 'prdContract', 'prdNamespace', 'stkIntContract', 'stkIntNamespace', 'wltIntContract', 'wltIntNamespace', 'pblIntContract', 'pblIntNamespace'];
 
 export default function DeveloperInfo() {
   const {connector, address} = useAccount();
@@ -63,6 +64,28 @@ export default function DeveloperInfo() {
               {!isInIframe &&
                 <Button className="w-28" onClick={() => handleCopy(ATP_LIST_HASH, 'atpListHash')}>
                   {buttonTexts.atpListHash}
+                </Button>
+              }
+            </div>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label>ATP Equivalent Hint List</Label>
+            <div className="flex content-between space-x-2">
+              <Input type="text" value={ATP_EQUIVALENT_LIST_HASH}/>
+              {!isInIframe &&
+                <Button className="w-28" onClick={() => handleCopy(ATP_EQUIVALENT_LIST_HASH, 'equivalentHash')}>
+                  {buttonTexts.equivalentHash}
+                </Button>
+              }
+            </div>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label>Authority Hint List</Label>
+            <div className="flex content-between space-x-2">
+              <Input type="text" value={AUTHORITY_LIST_HASH}/>
+              {!isInIframe &&
+                <Button className="w-28" onClick={() => handleCopy(AUTHORITY_LIST_HASH, 'authorityHash')}>
+                  {buttonTexts.authorityHash}
                 </Button>
               }
             </div>

--- a/components/tables/issuers/AddIssuerForm.tsx
+++ b/components/tables/issuers/AddIssuerForm.tsx
@@ -16,12 +16,11 @@ import {Check, ChevronsUpDown} from "lucide-react";
 import {Command, CommandEmpty, CommandGroup, CommandItem} from "../../ui/command";
 import {
   AddressType,
-  ATP_LIST_HASH,
   BYTES32_TRUE,
   cn,
   Environment,
   getAddress,
-  IDENTITY_LIST_HASH
+  getCredentialTypeListHash,
 } from "../../../lib/utils";
 import {CredentialType} from "./TrustedIssuerColumns";
 import {useAccount, useContractWrite, usePrepareContractWrite, useWaitForTransaction} from "wagmi";
@@ -34,16 +33,24 @@ const credentialTypes = [
     label: CredentialType.DSCSAATPCredential,
   },
   {
+    value: CredentialType.DSCSAAuthorityCredential.toLowerCase(),
+    label: CredentialType.DSCSAAuthorityCredential,
+  },
+  {
+    value: CredentialType.DSCSAATPEquivalentCredential.toLowerCase(),
+    label: CredentialType.DSCSAATPEquivalentCredential,
+  },
+  {
     value: CredentialType.IdentityCredential.toLowerCase(),
     label: CredentialType.IdentityCredential,
-  }
+  },
 ]
 
 export default function AddIssuerForm({ environment, refetch }: { environment: Environment, refetch: () => void }) {
   const {address} = useAccount();
   const [didValue, setDidValue] = useState("");
   const [nameValue, setNameValue] = useState("");
-  const [credentialTypeValue, setCredentialTypeValue] = useState("");
+  const [credentialTypeValue, setCredentialTypeValue] = useState(CredentialType.IdentityCredential.toLowerCase());
   const [open, setOpen] = useState(false);
 
   const registryAddress = getAddress(environment, AddressType.REGISTRY)
@@ -55,7 +62,7 @@ export default function AddIssuerForm({ environment, refetch }: { environment: E
     functionName: 'setHint',
     args: [
       safeAddress,
-      credentialTypeValue === CredentialType.DSCSAATPCredential.toLowerCase() ? ATP_LIST_HASH : IDENTITY_LIST_HASH,
+      getCredentialTypeListHash(credentialTypeValue),
       keccak256(stringToHex(didValue)),
       BYTES32_TRUE,
       stringToHex([didValue,nameValue].join(","))
@@ -113,7 +120,7 @@ export default function AddIssuerForm({ environment, refetch }: { environment: E
               className="col-span-3"
             />
           </div>
-          <div className="grid grid-cols-4 items-center gap-4">
+          <div className="grid grid-cols-4 items-center gap-4 truncate">
             <Label htmlFor="username" className="text-right">
               Type
             </Label>
@@ -123,7 +130,7 @@ export default function AddIssuerForm({ environment, refetch }: { environment: E
                   variant="outline"
                   role="combobox"
                   aria-expanded={open}
-                  className="col-span-3 justify-between font-normal"
+                  className="col-span-3 justify-between font-normal "
                 >
                   {credentialTypeValue
                     ? credentialTypes.find((credentialType) => credentialType.value === credentialTypeValue)?.label
@@ -131,7 +138,7 @@ export default function AddIssuerForm({ environment, refetch }: { environment: E
                   <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="w-[200px] p-0">
+              <PopoverContent className="w-[260px] p-0">
                 <Command>
                   <CommandEmpty>No credential type found.</CommandEmpty>
                   <CommandGroup>
@@ -139,7 +146,7 @@ export default function AddIssuerForm({ environment, refetch }: { environment: E
                       <CommandItem
                         key={credentialType.value}
                         onSelect={(currentValue) => {
-                          setCredentialTypeValue(currentValue === credentialTypeValue ? "" : currentValue)
+                          setCredentialTypeValue(currentValue)
                           setOpen(false)
                         }}
                       >

--- a/components/tables/issuers/RemoveIssuerButton.tsx
+++ b/components/tables/issuers/RemoveIssuerButton.tsx
@@ -5,15 +5,14 @@ import {TooltipProvider} from "@radix-ui/react-tooltip";
 import {Tooltip, TooltipContent, TooltipTrigger} from "../../ui/tooltip";
 import {
   AddressType,
-  ATP_LIST_HASH,
   BYTES32_FALSE,
   cn,
   Environment,
   getAddress,
-  IDENTITY_LIST_HASH
+  getCredentialTypeListHash,
 } from "../../../lib/utils";
 import {keccak256, stringToHex} from "viem";
-import {CredentialType, TrustedIssuer} from "./TrustedIssuerColumns";
+import {TrustedIssuer} from "./TrustedIssuerColumns";
 
 export function RemoveIssuerButton(row: Row<TrustedIssuer>, environment: Environment, refetch: () => void) {
   const { connector, address} = useAccount();
@@ -43,7 +42,7 @@ export function RemoveIssuerButton(row: Row<TrustedIssuer>, environment: Environ
             onClick={() => writeAllowed && removeIssuer?.({
               args: [
                 safeAddress,
-                trustedIssuer.credentialType === CredentialType.DSCSAATPCredential ? ATP_LIST_HASH : IDENTITY_LIST_HASH,
+                getCredentialTypeListHash(trustedIssuer.credentialType.toLowerCase()),
                 keccak256(stringToHex(trustedIssuer.did)),
                 BYTES32_FALSE,
               ],

--- a/components/tables/issuers/TrustedIssuerColumns.tsx
+++ b/components/tables/issuers/TrustedIssuerColumns.tsx
@@ -6,6 +6,8 @@ import {Environment} from "../../../lib/utils";
 
 export enum CredentialType {
   DSCSAATPCredential = "DSCSAATPCredential",
+  DSCSAATPEquivalentCredential = "DSCSAATPEquivalentCredential",
+  DSCSAAuthorityCredential = "DSCSAAuthorityCredential",
   IdentityCredential = "IdentityCredential",
   Unknown = "Unknown",
 }

--- a/components/tables/issuers/TrustedIssuerTable.tsx
+++ b/components/tables/issuers/TrustedIssuerTable.tsx
@@ -2,8 +2,14 @@ import {useEffect, useState} from "react";
 import {useAccount, useContractReads} from "wagmi";
 import {HintPath, useHintEvents} from "../../../hooks/useEvents";
 import {TRUSTED_HINT_ABI} from "../../../lib/abi";
-import {Address, encodePacked, fromHex, keccak256} from "viem";
-import {AddressType, ATP_LIST_HASH, detectEnvironment, Environment, getAddress} from "../../../lib/utils";
+import {Address, fromHex} from "viem";
+import {
+  AddressType,
+  detectEnvironment,
+  Environment,
+  getAddress,
+  getCredentialType
+} from "../../../lib/utils";
 import {CredentialType, TrustedIssuer, TrustedIssuerColumns} from "./TrustedIssuerColumns";
 import {
   ColumnFiltersState,
@@ -128,7 +134,7 @@ function TrustedIssuerDetailsTable({address, logs, metadata, environment, setEnv
       return {
         did: decoded[0],
         name: decoded[1],
-        credentialType: logs[i].list === ATP_LIST_HASH ? CredentialType.DSCSAATPCredential : CredentialType.IdentityCredential
+        credentialType: getCredentialType(logs[i].list)
       }
     }));
   }, [address, environment, metadata, logs]);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,7 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 import {Address} from "viem";
+import {CredentialType} from "../components/tables/issuers/TrustedIssuerColumns";
  
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -11,6 +12,8 @@ export const BYTES32_TRUE = "0x1000000000000000000000000000000000000000000000000
 
 export const ATP_LIST_HASH = "0xe35c2140155d7ab105ff242d32e532f2c9ae8597e9bc54107de56cd99f607551";
 export const IDENTITY_LIST_HASH = "0x1825a61b3b384c564efb355d7aee9ef08d663bb59b5d308146fcaeaa4a1de1ff";
+export const ATP_EQUIVALENT_LIST_HASH = "0x9310d05d293d16b5570d3fdb865933a6ff2bbd5aba4f444de323db71424f5bb1";
+export const AUTHORITY_LIST_HASH = "0x97f0fd57196c90295c810db7d7f59883372e22dc605202289343a99ec8021072";
 
 export const STK_INT_REGISTRY_ADDRESS = "0x6F68c931d785eee932d29A4419B6e28081bbb597";
 export const WLT_INT_REGISTRY_ADDRESS = "0x9497Bb14906aa6D4241Adf83708891fAe6ba171C";
@@ -78,6 +81,36 @@ export function detectEnvironment(walletAddress: Address) {
     return Environment.PRD;
   } else {
     return Environment.PBL_INT;
+  }
+}
+
+export function getCredentialType(credentialTypeListHash: string): CredentialType {
+  switch (credentialTypeListHash) {
+    case ATP_LIST_HASH:
+      return CredentialType.DSCSAATPCredential;
+    case ATP_EQUIVALENT_LIST_HASH:
+      return CredentialType.DSCSAATPEquivalentCredential;
+    case AUTHORITY_LIST_HASH:
+      return CredentialType.DSCSAAuthorityCredential;
+    case IDENTITY_LIST_HASH:
+      return CredentialType.IdentityCredential;
+    default:
+      return CredentialType.Unknown;
+  }
+}
+
+export function getCredentialTypeListHash(credentialType: string): `0x${string}` {
+  switch (credentialType) {
+    case CredentialType.DSCSAATPCredential.toLowerCase():
+      return ATP_LIST_HASH;
+    case CredentialType.DSCSAATPEquivalentCredential.toLowerCase():
+      return ATP_EQUIVALENT_LIST_HASH;
+    case CredentialType.DSCSAAuthorityCredential.toLowerCase():
+      return AUTHORITY_LIST_HASH;
+    case CredentialType.IdentityCredential.toLowerCase():
+      return IDENTITY_LIST_HASH;
+    default:
+      throw new Error(`No list hash found for credential type: ${credentialType}`)
   }
 }
 


### PR DESCRIPTION
This PR adds support for the new credential types `DSCSAATPEquivalentCredential` and `DSCSAAuthorityCredential`. The credential types are identified by:
- `https://open-credentialing-initiative.github.io/schemas/credentials/DSCSAATPEquivalentCredential-v1.0.0.jsonld` 
  - list hash `0x9310d05d293d16b5570d3fdb865933a6ff2bbd5aba4f444de323db71424f5bb1`
- `https://open-credentialing-initiative.github.io/schemas/credentials/DSCSAAuthorityCredential-v1.0.0.jsonld`
  - list hash `0x97f0fd57196c90295c810db7d7f59883372e22dc605202289343a99ec8021072`